### PR TITLE
fix: libatomic required for x86 builds as of this week

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ on:
       - main
       - master
     tags:
-      - '*'
+      - "*"
   pull_request:
   workflow_dispatch:
 
@@ -26,16 +26,22 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
+            before: ""
           - runner: ubuntu-22.04
             target: x86
+            before: "yum install libatomic -y"
           - runner: ubuntu-22.04
             target: aarch64
+            before: ""
           - runner: ubuntu-22.04
             target: armv7
+            before: ""
           - runner: ubuntu-22.04
             target: s390x
+            before: ""
           - runner: ubuntu-22.04
             target: ppc64le
+            before: ""
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -170,7 +176,7 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: 'wheels-*/*'
+          subject-path: "wheels-*/*"
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
             before: ""
           - runner: ubuntu-22.04
             target: x86
-            before: "yum install -y libatomic.i686"
+            before: "apt-get update && apt-get install -y libatomic libatomic.i686"
           - runner: ubuntu-22.04
             target: aarch64
             before: ""

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,22 +26,16 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
-            before: ""
           - runner: ubuntu-22.04
-            target: x86
-            before: "apt-get update && apt-get install -y libatomic libatomic.i686"
+            target: i686
           - runner: ubuntu-22.04
             target: aarch64
-            before: ""
           - runner: ubuntu-22.04
             target: armv7
-            before: ""
           - runner: ubuntu-22.04
             target: s390x
-            before: ""
           - runner: ubuntu-22.04
             target: ppc64le
-            before: ""
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -54,8 +48,6 @@ jobs:
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
-          before-script-linux: |
-            ${{ matrix.platform.before }}
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -70,7 +62,7 @@ jobs:
           - runner: ubuntu-22.04
             target: x86_64
           - runner: ubuntu-22.04
-            target: x86
+            target: i686
           - runner: ubuntu-22.04
             target: aarch64
           - runner: ubuntu-22.04

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,8 +42,8 @@ jobs:
         with:
           python-version: 3.x
       - name: Build wheels
-        uses: PyO3/maturin-action@v1.47.1
-        # uses: lmmx/maturin-action@v2
+        # uses: PyO3/maturin-action@v1.47.1
+        uses: lmmx/maturin-action@main
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,8 @@ jobs:
         with:
           python-version: 3.x
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        # uses: PyO3/maturin-action@v1
+        uses: lmmx/maturin-action@main
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
@@ -73,8 +74,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Build wheels
-        # uses: PyO3/maturin-action@v1
-        uses: lmmx/maturin-action@main
+        uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: 3.x
       - name: Build wheels
         # uses: PyO3/maturin-action@v1
-        uses: lmmx/maturin-action@v1
+        uses: lmmx/maturin-action@v2
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: 3.x
       - name: Build wheels
         # uses: PyO3/maturin-action@v1.47.1
-        uses: lmmx/maturin-action@main
+        uses: decentriq/maturin-action@main
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,7 +73,8 @@ jobs:
         with:
           python-version: 3.x
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        # uses: PyO3/maturin-action@v1
+        uses: lmmx/maturin-action@main
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,8 +42,8 @@ jobs:
         with:
           python-version: 3.x
       - name: Build wheels
-        # uses: PyO3/maturin-action@v1
-        uses: lmmx/maturin-action@v2
+        uses: PyO3/maturin-action@v1.47.1
+        # uses: lmmx/maturin-action@v2
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: 3.x
       - name: Build wheels
         # uses: PyO3/maturin-action@v1.47.1
-        uses: decentriq/maturin-action@main
+        uses: PyO3/maturin-action@refs/pull/330/head
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Build wheels
-        # uses: PyO3/maturin-action@v1 ...
+        # uses: PyO3/maturin-action@v1 ...?
         uses: lmmx/maturin-action@main
         with:
           target: ${{ matrix.platform.target }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,6 +54,8 @@ jobs:
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
+          before-script-linux: |
+            ${{ matrix.platform.before }}
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Build wheels
-        # uses: PyO3/maturin-action@v1 ...?
+        # uses: PyO3/maturin-action@v1 ...??
         uses: lmmx/maturin-action@main
         with:
           target: ${{ matrix.platform.target }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,16 +26,22 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
+            before: ""
           - runner: ubuntu-22.04
             target: x86
+            before: "yum install -y libatomic.i686"
           - runner: ubuntu-22.04
             target: aarch64
+            before: ""
           - runner: ubuntu-22.04
             target: armv7
+            before: ""
           - runner: ubuntu-22.04
             target: s390x
+            before: ""
           - runner: ubuntu-22.04
             target: ppc64le
+            before: ""
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,8 +42,8 @@ jobs:
         with:
           python-version: 3.x
       - name: Build wheels
-        # uses: PyO3/maturin-action@v1 ...??
-        uses: lmmx/maturin-action@main
+        # uses: PyO3/maturin-action@v1
+        uses: lmmx/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,22 +26,16 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
-            manylinux: auto
           - runner: ubuntu-22.04
             target: x86
-            manylinux: "2_24"
           - runner: ubuntu-22.04
             target: aarch64
-            manylinux: auto
           - runner: ubuntu-22.04
             target: armv7
-            manylinux: auto
           - runner: ubuntu-22.04
             target: s390x
-            manylinux: auto
           - runner: ubuntu-22.04
             target: ppc64le
-            manylinux: auto
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -53,7 +47,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-          manylinux: ${{ matrix.platform.manylinux }}
+          manylinux: auto
           before-script-linux: |
             ${{ matrix.platform.before }}
       - name: Upload wheels

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
           - runner: ubuntu-22.04
             target: x86_64
           - runner: ubuntu-22.04
-            target: i686
+            target: i686-unknown-linux-gnu
           - runner: ubuntu-22.04
             target: aarch64
           - runner: ubuntu-22.04

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,22 +26,22 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
-            before: ""
+            manylinux: auto
           - runner: ubuntu-22.04
             target: x86
-            before: "yum install libatomic -y"
+            manylinux: "2_24"
           - runner: ubuntu-22.04
             target: aarch64
-            before: ""
+            manylinux: auto
           - runner: ubuntu-22.04
             target: armv7
-            before: ""
+            manylinux: auto
           - runner: ubuntu-22.04
             target: s390x
-            before: ""
+            manylinux: auto
           - runner: ubuntu-22.04
             target: ppc64le
-            before: ""
+            manylinux: auto
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -53,7 +53,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-          manylinux: auto
+          manylinux: ${{ matrix.platform.manylinux }}
           before-script-linux: |
             ${{ matrix.platform.before }}
       - name: Upload wheels

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Build wheels
-        # uses: PyO3/maturin-action@v1
+        # uses: PyO3/maturin-action@v1 ...
         uses: lmmx/maturin-action@main
         with:
           target: ${{ matrix.platform.target }}


### PR DESCRIPTION
An OpenSSL bug (soon to be fixed by pinning to v3 upstream) means libatomic has begun to fail in the maturin-action setup

See https://github.com/rust-lang/cargo/issues/13546#issuecomment-2682833300

> You could install libatomic through your system package manager.

I `yum install` it in a before-script