### PR TITLE
feat: update to comrak 0.54 for `alert_style`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,138 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "anstream"
-version = "0.6.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
-dependencies = [
- "anstyle",
- "once_cell",
- "windows-sys",
-]
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
-
-[[package]]
-name = "bon"
-version = "3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7acc34ff59877422326db7d6f2d845a582b16396b6b08194942bf34c6528ab"
-dependencies = [
- "bon-macros",
- "rustversion",
-]
-
-[[package]]
-name = "bon-macros"
-version = "3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4159dd617a7fbc9be6a692fe69dc2954f8e6bb6bb5e4d7578467441390d77fd0"
-dependencies = [
- "darling",
- "ident_case",
- "prettyplease",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
-
-[[package]]
 name = "caseless"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,68 +10,6 @@ checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
 dependencies = [
  "unicode-normalization",
 ]
-
-[[package]]
-name = "cc"
-version = "1.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
-dependencies = [
- "shlex",
-]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "clap"
-version = "4.5.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
- "terminal_size",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "comrak"
@@ -219,75 +25,16 @@ version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d5910408554659ed848ff469e67ec83b30f179e72cec286cfdae64d1616f466"
 dependencies = [
- "bon",
  "caseless",
- "clap",
  "emojis",
  "entities",
  "finl_unicode",
- "fmt2io",
  "jetscii",
  "phf",
  "phf_codegen",
  "rustc-hash",
- "shell-words",
  "smallvec",
- "syntect",
  "typed-arena",
- "xdg",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
 ]
 
 [[package]]
@@ -306,32 +53,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "errno"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "fancy-regex"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
-dependencies = [
- "bit-set",
- "regex",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,66 +65,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
-name = "flate2"
-version = "1.0.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
-name = "fmt2io"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b6129284da9f7e5296cc22183a63f24300e945e297705dcc0672f7df01d62c8"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "indexmap"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itoa"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jetscii"
@@ -418,65 +83,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "memchr"
-version = "2.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
-dependencies = [
- "adler2",
-]
-
-[[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "onig"
-version = "6.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
-dependencies = [
- "cc",
- "pkg-config",
-]
 
 [[package]]
 name = "phf"
@@ -518,45 +128,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
-
-[[package]]
-name = "plist"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
-dependencies = [
- "base64",
- "indexmap",
- "quick-xml",
- "serde",
- "time",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "prettyplease"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
-dependencies = [
- "proc-macro2",
- "syn",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -626,15 +201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,73 +210,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
-
-[[package]]
-name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.8.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
-name = "rustversion"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
-
-[[package]]
-name = "ryu"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "serde"
@@ -733,30 +236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.138"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "shell-words"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,12 +246,6 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -786,94 +259,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "syntect"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
-dependencies = [
- "bincode",
- "bitflags 1.3.2",
- "fancy-regex",
- "flate2",
- "fnv",
- "once_cell",
- "onig",
- "plist",
- "regex-syntax",
- "serde",
- "serde_derive",
- "serde_json",
- "thiserror",
- "walkdir",
- "yaml-rust",
-]
-
-[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
-
-[[package]]
-name = "terminal_size"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
-dependencies = [
- "rustix",
- "windows-sys",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.3.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
-dependencies = [
- "num-conv",
- "time-core",
-]
 
 [[package]]
 name = "tinyvec"
@@ -909,117 +298,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
-]
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "xdg"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,27 +209,31 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 name = "comrak"
 version = "0.1.0"
 dependencies = [
- "comrak 0.49.0",
+ "comrak 0.54.0",
  "pyo3",
 ]
 
 [[package]]
 name = "comrak"
-version = "0.49.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab87129dce2f2d7e75e753b1df0e5093b27dec8fa5970b6eb51280faacb25bd6"
+checksum = "0d5910408554659ed848ff469e67ec83b30f179e72cec286cfdae64d1616f466"
 dependencies = [
  "bon",
  "caseless",
  "clap",
  "emojis",
  "entities",
+ "finl_unicode",
  "fmt2io",
  "jetscii",
+ "phf",
+ "phf_codegen",
+ "rustc-hash",
  "shell-words",
+ "smallvec",
  "syntect",
  "typed-arena",
- "unicode_categories",
  "xdg",
 ]
 
@@ -288,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "emojis"
-version = "0.6.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e1f1df1f181f2539bac8bf027d31ca5ffbf9e559e3f2d09413b9107b5c02f4"
+checksum = "0a4d5d50b0b58df5173d8ff1192b4d1422ceae5d981b30d4b6f8ed1d673a2bc4"
 dependencies = [
  "phf",
 ]
@@ -326,6 +330,18 @@ dependencies = [
  "bit-set",
  "regex",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "flate2"
@@ -464,18 +480,39 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
  "phf_shared",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -636,6 +673,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +761,12 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "strsim"
@@ -863,12 +912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,9 +1011,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xdg"
-version = "2.5.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [dependencies]
-comrak_lib = {package = "comrak", version = "0.49.0", features = ["shortcodes"]}
+comrak_lib = {package = "comrak", version = "0.54.0", features = ["shortcodes"]}
 pyo3 = {version = "0.28.3"}
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [dependencies]
-comrak_lib = {package = "comrak", version = "0.54.0", features = ["shortcodes"]}
+comrak_lib = {package = "comrak", version = "0.54.0", default-features = false, features = ["shortcodes"]}
 pyo3 = {version = "0.28.3"}
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ testpaths = "tests"
 addopts = "-v"
 
 [tool.ruff]
-extend-select = ["F", "UP"]
+lint.extend-select = ["F", "UP"]
 
 [tool.uv]
 # Build Rust code in development mode (faster builds)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use comrak_lib::{markdown_to_html, Options as ComrakOptions};
 
 // Import the Python option classes we defined
 mod options;
-use options::{PyExtensionOptions, PyParseOptions, PyRenderOptions, PyAlertStyle};
+use options::{PyAlertStyle, PyExtensionOptions, PyParseOptions, PyRenderOptions};
 
 /// Render a Markdown string to HTML, with optional Extension/Parse/Render overrides.
 #[pyfunction(signature=(text, extension_options=None, parse_options=None, render_options=None))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use comrak_lib::{markdown_to_html, Options as ComrakOptions};
 
 // Import the Python option classes we defined
 mod options;
-use options::{PyExtensionOptions, PyParseOptions, PyRenderOptions};
+use options::{PyExtensionOptions, PyParseOptions, PyRenderOptions, PyAlertStyle};
 
 /// Render a Markdown string to HTML, with optional Extension/Parse/Render overrides.
 #[pyfunction(signature=(text, extension_options=None, parse_options=None, render_options=None))]
@@ -43,6 +43,7 @@ fn comrak(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyExtensionOptions>()?;
     m.add_class::<PyParseOptions>()?;
     m.add_class::<PyRenderOptions>()?;
+    m.add_class::<PyAlertStyle>()?;
 
     Ok(())
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -226,7 +226,7 @@ pub struct PyRenderOptions {
     #[pyo3(get, set)]
     pub list_style: u8, // store 42 = '*', 43 = '+', 45 = '-'
     #[pyo3(get, set)]
-    alert_style: PyAlertStyle,
+    pub alert_style: PyAlertStyle,
     #[pyo3(get, set)]
     pub sourcepos: bool,
     #[pyo3(get, set)]

--- a/src/options.rs
+++ b/src/options.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 // Import the Comrak (Rust) types under `comrak_lib::`
 use comrak_lib::options::{
-    Extension as ComrakExtensionOptions, ListStyleType, Parse as ComrakParseOptions,
+    Extension as ComrakExtensionOptions, ListStyleType, AlertStyleType, Parse as ComrakParseOptions,
     Render as ComrakRenderOptions, URLRewriter,
 };
 
@@ -35,7 +35,7 @@ impl URLRewriter for PyURLRewriter {
 }
 
 /// Python class that mirrors Comrak's `ExtensionOptions`
-#[pyclass(name = "ExtensionOptions")]
+#[pyclass(name = "ExtensionOptions", from_py_object)]
 #[derive(Clone)]
 pub struct PyExtensionOptions {
     #[pyo3(get, set)]
@@ -51,7 +51,7 @@ pub struct PyExtensionOptions {
     #[pyo3(get, set)]
     pub superscript: bool,
     #[pyo3(get, set)]
-    pub header_ids: Option<String>,
+    pub header_id_prefix: Option<String>,
     #[pyo3(get, set)]
     pub footnotes: bool,
     #[pyo3(get, set)]
@@ -94,7 +94,7 @@ impl PyExtensionOptions {
         opts.autolink = self.autolink;
         opts.tasklist = self.tasklist;
         opts.superscript = self.superscript;
-        opts.header_ids = self.header_ids.clone();
+        opts.header_id_prefix = self.header_id_prefix.clone();
         opts.footnotes = self.footnotes;
         opts.description_lists = self.description_lists;
         opts.front_matter_delimiter = self.front_matter_delimiter.clone();
@@ -125,7 +125,7 @@ impl PyExtensionOptions {
             autolink: defaults.autolink,
             tasklist: defaults.tasklist,
             superscript: defaults.superscript,
-            header_ids: defaults.header_ids.clone(),
+            header_id_prefix: defaults.header_id_prefix.clone(),
             footnotes: defaults.footnotes,
             description_lists: defaults.description_lists,
             front_matter_delimiter: defaults.front_matter_delimiter.clone(),
@@ -153,7 +153,7 @@ impl PyExtensionOptions {
 }
 
 /// Python class that mirrors Comrak’s `ParseOptions`
-#[pyclass(name = "ParseOptions")]
+#[pyclass(name = "ParseOptions", from_py_object)]
 #[derive(Clone)]
 pub struct PyParseOptions {
     #[pyo3(get, set)]
@@ -195,7 +195,7 @@ impl PyParseOptions {
 }
 
 /// Python class that mirrors Comrak’s `RenderOptions`
-#[pyclass(name = "RenderOptions")]
+#[pyclass(name = "RenderOptions", from_py_object)]
 #[derive(Clone)]
 pub struct PyRenderOptions {
     #[pyo3(get, set)]
@@ -212,6 +212,8 @@ pub struct PyRenderOptions {
     pub escape: bool,
     #[pyo3(get, set)]
     pub list_style: u8, // store 42 = '*', 43 = '+', 45 = '-'
+    #[pyo3(get, set)]
+    alert_style: PyAlertStyle,
     #[pyo3(get, set)]
     pub sourcepos: bool,
     #[pyo3(get, set)]
@@ -230,6 +232,31 @@ pub struct PyRenderOptions {
     pub ol_width: usize,
 }
 
+#[derive(Clone, Copy, Debug)]
+#[pyclass(name = "AlertStyle", from_py_object)]
+pub enum PyAlertStyle {
+    Specific,
+    Semantic,
+}
+
+impl Into<AlertStyleType> for PyAlertStyle {
+    fn into(self) -> AlertStyleType {
+        match self {
+            PyAlertStyle::Specific => AlertStyleType::Specific,
+            PyAlertStyle::Semantic => AlertStyleType::Semantic,
+        }
+    }
+}
+
+impl Into<PyAlertStyle> for AlertStyleType {
+    fn into(self) -> PyAlertStyle {
+        match self {
+            AlertStyleType::Specific => PyAlertStyle::Specific,
+            AlertStyleType::Semantic => PyAlertStyle::Semantic,
+        }
+    }
+}
+
 impl PyRenderOptions {
     /// Rust-only helper
     pub fn update_render_options(&self, opts: &mut ComrakRenderOptions) {
@@ -245,6 +272,7 @@ impl PyRenderOptions {
             42 => ListStyleType::Star, // '*'
             _ => ListStyleType::Dash,  // '-'
         };
+        opts.alert_style = self.alert_style.into();
         opts.sourcepos = self.sourcepos;
         opts.escaped_char_spans = self.escaped_char_spans;
         opts.ignore_empty_links = self.ignore_empty_links;
@@ -269,6 +297,7 @@ impl PyRenderOptions {
             unsafe_: defaults.r#unsafe,
             escape: defaults.escape,
             list_style: defaults.list_style as u8, // 45 if dash
+            alert_style: defaults.alert_style.into(),
             sourcepos: defaults.sourcepos,
             escaped_char_spans: defaults.escaped_char_spans,
             ignore_empty_links: defaults.ignore_empty_links,

--- a/src/options.rs
+++ b/src/options.rs
@@ -252,18 +252,18 @@ pub enum PyAlertStyle {
     Semantic,
 }
 
-impl Into<AlertStyleType> for PyAlertStyle {
-    fn into(self) -> AlertStyleType {
-        match self {
+impl From<PyAlertStyle> for AlertStyleType {
+    fn from(val: PyAlertStyle) -> Self {
+        match val {
             PyAlertStyle::Specific => AlertStyleType::Specific,
             PyAlertStyle::Semantic => AlertStyleType::Semantic,
         }
     }
 }
 
-impl Into<PyAlertStyle> for AlertStyleType {
-    fn into(self) -> PyAlertStyle {
-        match self {
+impl From<AlertStyleType> for PyAlertStyle {
+    fn from(val: AlertStyleType) -> Self {
+        match val {
             AlertStyleType::Specific => PyAlertStyle::Specific,
             AlertStyleType::Semantic => PyAlertStyle::Semantic,
         }

--- a/src/options.rs
+++ b/src/options.rs
@@ -36,7 +36,7 @@ impl URLRewriter for PyURLRewriter {
 }
 
 /// Python class that mirrors Comrak's `ExtensionOptions`
-#[pyclass(name = "ExtensionOptions", from_py_object)]
+#[pyclass(name = "ExtensionOptions", module = "comrak", from_py_object)]
 #[derive(Clone)]
 pub struct PyExtensionOptions {
     #[pyo3(get, set)]
@@ -166,7 +166,7 @@ impl PyExtensionOptions {
 }
 
 /// Python class that mirrors Comrak’s `ParseOptions`
-#[pyclass(name = "ParseOptions", from_py_object)]
+#[pyclass(name = "ParseOptions", module = "comrak", from_py_object)]
 #[derive(Clone)]
 pub struct PyParseOptions {
     #[pyo3(get, set)]
@@ -208,7 +208,7 @@ impl PyParseOptions {
 }
 
 /// Python class that mirrors Comrak’s `RenderOptions`
-#[pyclass(name = "RenderOptions", from_py_object)]
+#[pyclass(name = "RenderOptions", module = "comrak", from_py_object)]
 #[derive(Clone)]
 pub struct PyRenderOptions {
     #[pyo3(get, set)]
@@ -246,7 +246,7 @@ pub struct PyRenderOptions {
 }
 
 #[derive(Clone, Copy, Debug)]
-#[pyclass(name = "AlertStyle", from_py_object)]
+#[pyclass(name = "AlertStyle", module = "comrak", from_py_object)]
 pub enum PyAlertStyle {
     Specific,
     Semantic,

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,4 +1,5 @@
 use pyo3::prelude::*;
+use pyo3::exceptions::PyFutureWarning;
 use std::panic::RefUnwindSafe;
 use std::sync::Arc;
 
@@ -149,6 +150,18 @@ impl PyExtensionOptions {
     #[setter]
     pub fn set_link_url_rewriter(&mut self, callback: Option<Py<PyAny>>) {
         self.link_url_rewriter = callback.map(|cb| Arc::new(PyURLRewriter::new(cb)) as _);
+    }
+
+    #[getter]
+    #[pyo3(warn(message = "Use `header_id_prefix` instead", category = PyFutureWarning))]
+    pub fn header_ids(&self) -> Option<String> {
+        self.header_id_prefix.clone()
+    }
+
+    #[setter]
+    #[pyo3(warn(message = "Use `header_id_prefix` instead", category = PyFutureWarning))]
+    pub fn set_header_ids(&mut self, prefix: Option<String>) {
+        self.header_id_prefix = prefix;
     }
 }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,12 +1,12 @@
-use pyo3::prelude::*;
 use pyo3::exceptions::PyFutureWarning;
+use pyo3::prelude::*;
 use std::panic::RefUnwindSafe;
 use std::sync::Arc;
 
 // Import the Comrak (Rust) types under `comrak_lib::`
 use comrak_lib::options::{
-    Extension as ComrakExtensionOptions, ListStyleType, AlertStyleType, Parse as ComrakParseOptions,
-    Render as ComrakRenderOptions, URLRewriter,
+    AlertStyleType, Extension as ComrakExtensionOptions, ListStyleType,
+    Parse as ComrakParseOptions, Render as ComrakRenderOptions, URLRewriter,
 };
 
 /// A wrapper around a Python callable that implements URLRewriter.

--- a/src/options.rs
+++ b/src/options.rs
@@ -245,8 +245,8 @@ pub struct PyRenderOptions {
     pub ol_width: usize,
 }
 
-#[derive(Clone, Copy, Debug)]
-#[pyclass(name = "AlertStyle", module = "comrak", from_py_object)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq)]
+#[pyclass(name = "AlertStyle", module = "comrak", from_py_object, eq, eq_int, frozen, hash)]
 pub enum PyAlertStyle {
     Specific,
     Semantic,

--- a/tests/comrak_test.py
+++ b/tests/comrak_test.py
@@ -1,5 +1,5 @@
-import pytest
 import comrak
+import pytest
 
 
 class TestBasicRendering:
@@ -307,3 +307,49 @@ class TestRegressions:
         markdown = "\n".join([f"# Heading {i}" for i in range(1000)])
         result = comrak.render_markdown(markdown)
         assert result.count("<h1>") == 1000
+
+
+class TestAlertStyle:
+    """Test AlertStyle enum ergonomics (eq, eq_int, hash, module)."""
+
+    def test_value_equality(self):
+        """Same variant compares equal even across separate object instances."""
+        assert comrak.AlertStyle.Specific == comrak.AlertStyle.Specific
+        assert comrak.AlertStyle.Semantic == comrak.AlertStyle.Semantic
+        assert comrak.AlertStyle.Specific != comrak.AlertStyle.Semantic
+
+    @pytest.mark.parametrize(
+        ("style", "expected_int"),
+        [
+            pytest.param(comrak.AlertStyle.Specific, 0, id="specific"),
+            pytest.param(comrak.AlertStyle.Semantic, 1, id="semantic"),
+        ],
+    )
+    def test_int_conversion(self, style, expected_int):
+        """int() reflects the variant's discriminant."""
+        assert int(style) == expected_int
+
+    @pytest.mark.parametrize(
+        ("style", "matching_int", "other_int"),
+        [
+            pytest.param(comrak.AlertStyle.Specific, 0, 1, id="specific"),
+            pytest.param(comrak.AlertStyle.Semantic, 1, 0, id="semantic"),
+        ],
+    )
+    def test_eq_int(self, style, matching_int, other_int):
+        """eq_int allows comparison against the raw discriminant."""
+        assert style == matching_int
+        assert style != other_int
+
+    def test_hashable(self):
+        """frozen + hash make AlertStyle usable as a dict key / set member."""
+        mapping = {
+            comrak.AlertStyle.Specific: "specific",
+            comrak.AlertStyle.Semantic: "semantic",
+        }
+        assert mapping[comrak.AlertStyle.Specific] == "specific"
+        assert len({comrak.AlertStyle.Specific, comrak.AlertStyle.Specific}) == 1
+
+    def test_module(self):
+        """module='comrak' fixes repr and qualified name for pickling."""
+        assert comrak.AlertStyle.__module__ == "comrak"

--- a/tests/comrak_test.py
+++ b/tests/comrak_test.py
@@ -1,3 +1,4 @@
+import pytest
 import comrak
 
 
@@ -165,6 +166,36 @@ class TestRenderOptions:
         result = comrak.render_markdown(markdown)
         # By default, HTML should be escaped or removed
         assert "<script>" not in result or "&lt;script&gt;" in result
+
+    @pytest.mark.parametrize(
+        ("style", "expected"),
+        [
+            pytest.param(
+                comrak.AlertStyle.Specific,
+                '<div class="markdown-alert markdown-alert-note">\n'
+                '<p class="markdown-alert-title">Note</p>\n'
+                '<p>Note this!</p>\n'
+                '</div>',
+                id="specific",
+            ),
+            pytest.param(
+                comrak.AlertStyle.Semantic,
+                '<aside class="admonition note">\n'
+                '<p class="admonition-title">Note</p>\n'
+                '<p>Note this!</p>\n'
+                '</aside>',
+                id="semantic",
+            ),
+        ]
+    )
+    def test_alerts(self, style: comrak.AlertStyle, expected: str) -> None:
+        e_opts = comrak.ExtensionOptions()
+        e_opts.alerts = True
+        r_opts = comrak.RenderOptions()
+        r_opts.alert_style = style
+        markdown = "> [!note]\n> Note this!"
+        result = comrak.render_markdown(markdown, extension_options=e_opts, render_options=r_opts)
+        assert expected in result
 
 
 class TestOptionsObjects:

--- a/tests/comrak_test.py
+++ b/tests/comrak_test.py
@@ -174,19 +174,19 @@ class TestRenderOptions:
                 comrak.AlertStyle.Specific,
                 '<div class="markdown-alert markdown-alert-note">\n'
                 '<p class="markdown-alert-title">Note</p>\n'
-                '<p>Note this!</p>\n'
-                '</div>',
+                "<p>Note this!</p>\n"
+                "</div>",
                 id="specific",
             ),
             pytest.param(
                 comrak.AlertStyle.Semantic,
                 '<aside class="admonition note">\n'
                 '<p class="admonition-title">Note</p>\n'
-                '<p>Note this!</p>\n'
-                '</aside>',
+                "<p>Note this!</p>\n"
+                "</aside>",
                 id="semantic",
             ),
-        ]
+        ],
     )
     def test_alerts(self, style: comrak.AlertStyle, expected: str) -> None:
         e_opts = comrak.ExtensionOptions()
@@ -194,7 +194,9 @@ class TestRenderOptions:
         r_opts = comrak.RenderOptions()
         r_opts.alert_style = style
         markdown = "> [!note]\n> Note this!"
-        result = comrak.render_markdown(markdown, extension_options=e_opts, render_options=r_opts)
+        result = comrak.render_markdown(
+            markdown, extension_options=e_opts, render_options=r_opts
+        )
         assert expected in result
 
 

--- a/tests/link_url_rewriter_test.py
+++ b/tests/link_url_rewriter_test.py
@@ -68,8 +68,8 @@ class TestLinkUrlRewriter:
         # Image URL should NOT be rewritten
         assert "http://example.com/image.png" in result
 
-    def test_with_header_ids_prefix(self):
-        """Test rewriting anchor links to match header_ids prefix.
+    def test_with_header_id_prefix(self):
+        """Test rewriting anchor links to match `header_id_prefix`.
 
         When using header_ids with a prefix like "user-content-", the generated
         header anchors will have that prefix. This example shows how to use

--- a/tests/link_url_rewriter_test.py
+++ b/tests/link_url_rewriter_test.py
@@ -71,7 +71,7 @@ class TestLinkUrlRewriter:
     def test_with_header_id_prefix(self):
         """Test rewriting anchor links to match `header_id_prefix`.
 
-        When using header_ids with a prefix like "user-content-", the generated
+        When using header_id_prefix with a prefix like "user-content-", the generated
         header anchors will have that prefix. This example shows how to use
         link_url_rewriter to update anchor links written in markdown to match.
 

--- a/tests/link_url_rewriter_test.py
+++ b/tests/link_url_rewriter_test.py
@@ -80,7 +80,7 @@ class TestLinkUrlRewriter:
         """
         opts = comrak.ExtensionOptions()
         prefix = "user-content-"
-        opts.header_ids = prefix
+        opts.header_id_prefix = prefix
         opts.link_url_rewriter = lambda url: (
             f"#{prefix}{url[1:]}" if url.startswith("#") else url
         )


### PR DESCRIPTION
Adds the render option `alert_style` plus enum.

Would be awesome to get this in a release soon for https://github.com/pypa/readme_renderer/issues/378

Also renames `header_ids` to `header_id_prefix` complete with backwards compat `@property`