### PR TITLE
feat: render CommonMark

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ pip install comrak
 '<h1>Hello</h1>\n'
 ```
 
+### CommonMark output
+
+`render_commonmark` renders Markdown back to normalized CommonMark instead of
+HTML. It takes the same `extension_options`/`parse_options`/`render_options`
+as `render_markdown`:
+
+```py
+>>> comrak.render_commonmark("- one\n- two\n- three")
+'- one\n- two\n- three\n'
+>>> opts = comrak.RenderOptions()
+>>> opts.list_style = comrak.ListStyle.Plus
+>>> comrak.render_commonmark("- one\n- two\n- three", render_options=opts)
+'+ one\n+ two\n+ three\n'
+```
+
 ### Options
 
 Every option in comrak's `Extension`, `Parse` and `Render` structs is exposed,
@@ -82,11 +97,14 @@ raises a `FutureWarning`; it will be removed in a future release.
 - `parse.broken_link_callback` — [see tracking issue](https://github.com/lmmx/comrak/issues/58)
 - `extension.phoenix_heex` — gated behind a comrak crate feature that isn't built here
 - Plugins (syntax highlighting, heading adapters)
+- XML output (`comrak::markdown_to_commonmark_xml`)
 
-Only HTML output is available, via `render_markdown`. The options that solely
-affect comrak's CommonMark formatter (`width`, `list_style`, `prefer_fenced`,
-`ol_width`, `experimental_minimize_commonmark`) are settable for API parity but
-currently have no effect.
+`render_markdown` renders to HTML. `render_commonmark` renders to normalized
+[CommonMark][commonmark]. The options that solely affect the CommonMark formatter (`width`,
+`list_style`, `prefer_fenced`, `ol_width`, `experimental_minimize_commonmark`)
+have no effect on `render_markdown`'s HTML output, only on `render_commonmark`.
+
+[commonmark]: https://commonmark.org/
 
 ## Benchmarks
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 
 // We renamed the Rust library to `comrak_lib`
-use comrak_lib::{markdown_to_html, Options as ComrakOptions};
+use comrak_lib::{markdown_to_commonmark, markdown_to_html, Options as ComrakOptions};
 
 // Import the Python option classes we defined
 mod options;
@@ -34,8 +34,36 @@ fn render_markdown(
     Ok(html)
 }
 
+/// Render a Markdown string back to normalized CommonMark, with optional Extension/Parse/Render overrides.
+#[pyfunction(signature=(text, extension_options=None, parse_options=None, render_options=None))]
+fn render_commonmark(
+    text: &str,
+    extension_options: Option<PyExtensionOptions>,
+    parse_options: Option<PyParseOptions>,
+    render_options: Option<PyRenderOptions>,
+) -> PyResult<String> {
+    let mut opts = ComrakOptions::default();
+
+    if let Some(py_ext) = extension_options {
+        py_ext.update_extension_options(&mut opts.extension);
+    }
+
+    if let Some(py_parse) = parse_options {
+        py_parse.update_parse_options(&mut opts.parse);
+    }
+
+    if let Some(py_render) = render_options {
+        py_render.update_render_options(&mut opts.render);
+    }
+
+    let cm = markdown_to_commonmark(text, &opts);
+    Ok(cm)
+}
+
 #[pymodule(gil_used = false)]
 mod comrak {
+    #[pymodule_export]
+    use super::render_commonmark;
     #[pymodule_export]
     use super::render_markdown;
 

--- a/tests/comrak_test.py
+++ b/tests/comrak_test.py
@@ -6,8 +6,8 @@ they need in order to be observable in HTML output:
 * toggles with a self-contained markdown/HTML signature live in a table,
   driven by ``assert_toggle`` (off -> absent, on -> present);
 * options with prerequisites or non-boolean values get their own test;
-* options that only affect non-HTML formatters are round-tripped, since
-  ``render_markdown`` cannot observe them.
+* options that only affect the CommonMark formatter are tested against
+  ``render_commonmark`` rather than ``render_markdown``.
 
 ``TestOptionCoverage`` asserts every public attribute is accounted for.
 """
@@ -539,8 +539,8 @@ RENDER_TOGGLES = [
     pytest.param("ignore_empty_links", "[](foo)", "[](foo)", id="ignore_empty_links"),
 ]
 
-#: Render options that only affect the CommonMark formatter, which
-#: ``render_markdown`` does not use. Round-tripped rather than untested.
+#: Render options that only affect the CommonMark formatter, exercised
+#: against ``render_commonmark`` in ``TestCommonmarkOutput`` below.
 COMMONMARK_ONLY_RENDER_OPTIONS = {
     "width": 80,
     "prefer_fenced": True,
@@ -554,12 +554,6 @@ class TestRenderOptions:
     @pytest.mark.parametrize(("attr", "markdown", "expected"), RENDER_TOGGLES)
     def test_toggle(self, attr, markdown, expected):
         assert_toggle("RenderOptions", attr, markdown, expected)
-
-    @pytest.mark.parametrize(
-        ("attr", "value"), sorted(COMMONMARK_ONLY_RENDER_OPTIONS.items())
-    )
-    def test_commonmark_only_round_trip(self, attr, value):
-        assert_round_trip("RenderOptions", attr, value)
 
     def test_unsafe(self):
         opts = comrak.RenderOptions()
@@ -650,6 +644,93 @@ class TestRenderOptions:
         opts.compact_html = True
         assert comrak.render_markdown(markdown, render_options=opts) == (
             "<h1>Hello</h1><p>World.</p>"
+        )
+
+
+# --------------------------------------------------------------------------
+# CommonMark output
+# --------------------------------------------------------------------------
+
+
+class TestCommonmarkOutput:
+    """``render_commonmark`` renders Markdown back to normalized CommonMark."""
+
+    def test_basic(self):
+        assert comrak.render_commonmark("hello world") == "hello world\n"
+
+    def test_width(self):
+        opts = comrak.RenderOptions()
+        markdown = "hello hello hello hello hello hello"
+
+        assert comrak.render_commonmark(markdown, render_options=opts) == (
+            "hello hello hello hello hello hello\n"
+        )
+
+        opts.width = 20
+        assert comrak.render_commonmark(markdown, render_options=opts) == (
+            "hello hello hello\nhello hello hello\n"
+        )
+
+    def test_list_style(self):
+        opts = comrak.RenderOptions()
+        markdown = "- one\n- two\n- three"
+
+        assert comrak.render_commonmark(markdown, render_options=opts) == (
+            "- one\n- two\n- three\n"
+        )
+
+        opts.list_style = comrak.ListStyle.Plus
+        assert comrak.render_commonmark(markdown, render_options=opts) == (
+            "+ one\n+ two\n+ three\n"
+        )
+
+        opts.list_style = comrak.ListStyle.Star
+        assert comrak.render_commonmark(markdown, render_options=opts) == (
+            "* one\n* two\n* three\n"
+        )
+
+    def test_ol_width(self):
+        opts = comrak.RenderOptions()
+        markdown = "1. Something"
+
+        assert comrak.render_commonmark(markdown, render_options=opts) == (
+            "1. Something\n"
+        )
+
+        opts.ol_width = 5
+        assert comrak.render_commonmark(markdown, render_options=opts) == (
+            "1.   Something\n"
+        )
+
+    def test_prefer_fenced(self):
+        opts = comrak.RenderOptions()
+        markdown = "```\nhello\n```\n"
+
+        assert comrak.render_commonmark(markdown, render_options=opts) == "    hello\n"
+
+        opts.prefer_fenced = True
+        assert comrak.render_commonmark(markdown, render_options=opts) == (
+            "```\nhello\n```\n"
+        )
+
+    def test_experimental_minimize_commonmark(self):
+        opts = comrak.RenderOptions()
+        markdown = "__hi"
+
+        assert comrak.render_commonmark(markdown, render_options=opts) == "\\_\\_hi\n"
+
+        opts.experimental_minimize_commonmark = True
+        assert comrak.render_commonmark(markdown, render_options=opts) == "__hi\n"
+
+    def test_options_are_independent_of_render_markdown(self):
+        """The same ``RenderOptions`` object drives both formatters independently."""
+        opts = comrak.RenderOptions()
+        opts.list_style = comrak.ListStyle.Plus
+        markdown = "- one\n- two"
+
+        assert "<li>one</li>" in comrak.render_markdown(markdown, render_options=opts)
+        assert comrak.render_commonmark(markdown, render_options=opts) == (
+            "+ one\n+ two\n"
         )
 
 


### PR DESCRIPTION
After plumbing the CommonMark opts in #82, also now wrap the `render_commonmark` func to actually use them